### PR TITLE
Fixed minor bug in find_all()

### DIFF
--- a/botcity/core/bot.py
+++ b/botcity/core/bot.py
@@ -309,8 +309,8 @@ class DesktopBot(BaseBot):
                 for itm in items:
                     if itm == item:
                         continue
-                    if (itm.left >= x_start and itm.left <= x_end)\
-                            and (itm.top >= y_start and itm.top <= y_end):
+                    if (itm.left >= x_start and itm.left < x_end)\
+                            and (itm.top >= y_start and itm.top < y_end):
                         similars.append(itm)
                         continue
                 return similars


### PR DESCRIPTION
FIXED: If two matches were next to each other, but without at least a pixel separating them, the bot would consider them to be duplicates.