### PR TITLE
FIX: Removing x and y axis sum on 'right_click_relative' method

### DIFF
--- a/botcity/core/bot.py
+++ b/botcity/core/bot.py
@@ -789,8 +789,6 @@ class DesktopBot(BaseBot):
             interval_between_clicks (int, optional): The interval between clicks in ms. Defaults to 0.
             wait_after (int, optional): Interval to wait after clicking on the element.
         """
-        x = self.state.x() + x
-        y = self.state.y() + y
         self.click_relative(x, y, wait_after=wait_after, clicks=3, interval_between_clicks=interval_between_clicks,
                             button='right')
 


### PR DESCRIPTION
# Problem
`X` and `Y` values were being summed twice.