### PR TITLE
Fix click on element error

### DIFF
--- a/botcity/core/bot.py
+++ b/botcity/core/bot.py
@@ -480,7 +480,8 @@ class DesktopBot(BaseBot):
                 the first find. Defaults to True.
 
         Returns:
-            coords (Tuple): A tuple containing the x and y coordinates for the element.
+            coords (Tuple): A tuple containing the x and y coordinates for the element finded.
+                Tuple containing None values if not found.
         """
         self.state.element = None
         screen_size = pyautogui.size()
@@ -494,10 +495,12 @@ class DesktopBot(BaseBot):
             print('Warning: Ignoring best=False for now. It will be supported in the future.')
 
         ele = pyautogui.locateOnScreen(self._search_image_file(label), region=region, confidence=matching)
-        if is_retina():
-            ele = ele._replace(left=ele.left / 2.0, top=ele.top / 2.0)
-        self.state.element = ele
-        return ele.left, ele.top
+        if ele is not None:
+            if is_retina():
+                ele = ele._replace(left=ele.left / 2.0, top=ele.top / 2.0)
+            self.state.element = ele
+            return ele.left, ele.top
+        return None, None
 
     def get_element_coords_centered(self, label, x=None, y=None, width=None, height=None,
                                     matching=0.9, best=True):
@@ -546,16 +549,21 @@ class DesktopBot(BaseBot):
     # Mouse
     #######
 
-    @only_if_element
     def click_on(self, label):
         """
         Click on the element.
 
         Args:
             label (str): The image identifier
+
+        Returns:
+            status (bool): True if the element is founded, False otherwise.
         """
         x, y = self.get_element_coords_centered(label)
-        os_compat.click(x, y)
+        if None not in (x, y):
+            os_compat.click(x, y)
+            return True
+        return False
 
     def get_last_x(self):
         """

--- a/botcity/core/bot.py
+++ b/botcity/core/bot.py
@@ -789,8 +789,6 @@ class DesktopBot(BaseBot):
             interval_between_clicks (int, optional): The interval between clicks in ms. Defaults to 0.
             wait_after (int, optional): Interval to wait after clicking on the element.
         """
-        x = self.state.x() + x
-        y = self.state.y() + y
         self.click_relative(x, y, wait_after=wait_after, clicks=3, interval_between_clicks=interval_between_clicks,
                             button='right')
 


### PR DESCRIPTION
# Problem
1. `click_on` method raises the error before finding an element on the screen.
2. Handles error if element is not found.