### PR TITLE
BLD: Require Pillow>=8.1.1 for Linux and XCB support.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-botcity-framework-base>=0.4.0,<1.0
+botcity-framework-base>=0.4.2,<1.0
 pyperclip
 opencv-python
 python-xlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ python-xlib
 pywinauto
 pynput
 psutil
-Pillow
+Pillow>=8.1.1


### PR DESCRIPTION
Closes #44 