### PR TITLE
MNT: Removing numpy lock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pywinauto
 pynput
 psutil
 Pillow>=8.1.1
-numpy<2
+numpy


### PR DESCRIPTION
Removing the `numpy<2` lock since now `opencv-python` supports numpy > 2.

This also resolves the issue with installing the package using Python 3.13. Card for reference: https://www.notion.so/botcity/Problem-preparing-environment-12dd76539ac3815daa5bcae07d6ed4b6?d=189d76539ac380a2b66a001c988b122d