### PR TITLE
MNT: Add type hints to Mouse methods

### DIFF
--- a/botcity/core/bot.py
+++ b/botcity/core/bot.py
@@ -6,7 +6,7 @@ import random
 import subprocess
 import time
 import webbrowser
-from typing import Union, Tuple, Optional, List, Dict, Generator, Any, Literal
+from typing import Union, Tuple, Optional, List, Dict, Generator, Any
 
 from numpy import ndarray
 

--- a/botcity/core/bot.py
+++ b/botcity/core/bot.py
@@ -6,7 +6,7 @@ import random
 import subprocess
 import time
 import webbrowser
-from typing import Union, Tuple, Optional, List, Dict, Generator, Any
+from typing import Union, Tuple, Optional, List, Dict, Generator, Any, Literal
 
 from numpy import ndarray
 
@@ -761,7 +761,7 @@ class DesktopBot(BaseBot):
         height: Optional[int] = None,
         matching: float = 0.9,
         best: bool = True,
-    ):
+    ) -> Union[Tuple[int, int], Tuple[None, None]]:
         """
         Find an element defined by label on screen and returns its centered coordinates.
 
@@ -807,7 +807,7 @@ class DesktopBot(BaseBot):
     # Mouse
     #######
 
-    def click_on(self, label):
+    def click_on(self, label: str) -> None:
         """
         Click on the element.
 
@@ -819,7 +819,7 @@ class DesktopBot(BaseBot):
             raise ValueError(f"Element not available. Cannot find {label}.")
         _mouse_click(self._mouse_controller, x, y)
 
-    def get_last_x(self):
+    def get_last_x(self) -> int:
         """
         Get the last X position for the mouse.
 
@@ -828,7 +828,7 @@ class DesktopBot(BaseBot):
         """
         return self._mouse_controller.position[0]
 
-    def get_last_y(self):
+    def get_last_y(self) -> int:
         """
         Get the last Y position for the mouse.
 
@@ -837,7 +837,7 @@ class DesktopBot(BaseBot):
         """
         return self._mouse_controller.position[1]
 
-    def mouse_move(self, x, y):
+    def mouse_move(self, x: int, y: int) -> None:
         """
         Move the mouse to the coordinate defined by x and y
 
@@ -849,7 +849,7 @@ class DesktopBot(BaseBot):
         self._mouse_controller.position = (x, y)
         self.sleep(config.DEFAULT_SLEEP_AFTER_ACTION)
 
-    def click_at(self, x, y):
+    def click_at(self, x: int, y: int) -> None:
         """
         Click at the coordinate defined by x and y
 
@@ -862,12 +862,12 @@ class DesktopBot(BaseBot):
     @only_if_element
     def click(
         self,
-        wait_after=config.DEFAULT_SLEEP_AFTER_ACTION,
+        wait_after: int = config.DEFAULT_SLEEP_AFTER_ACTION,
         *,
-        clicks=1,
-        interval_between_clicks=0,
-        button="left",
-    ):
+        clicks: int = 1,
+        interval_between_clicks: int = 0,
+        button: Literal["left", "right", "middle"] = "left",
+    ) -> None:
         """
         Click on the last found element.
 
@@ -886,14 +886,14 @@ class DesktopBot(BaseBot):
     @only_if_element
     def click_relative(
         self,
-        x,
-        y,
-        wait_after=config.DEFAULT_SLEEP_AFTER_ACTION,
+        x: int,
+        y: int,
+        wait_after: int = config.DEFAULT_SLEEP_AFTER_ACTION,
         *,
-        clicks=1,
-        interval_between_clicks=0,
-        button="left",
-    ):
+        clicks: int = 1,
+        interval_between_clicks: int = 0,
+        button: Literal["left", "right", "middle"] = "left",
+    ) -> None:
         """
         Click Relative on the last found element.
 
@@ -913,7 +913,7 @@ class DesktopBot(BaseBot):
         self.sleep(wait_after)
 
     @only_if_element
-    def double_click(self, wait_after=config.DEFAULT_SLEEP_AFTER_ACTION):
+    def double_click(self, wait_after: int = config.DEFAULT_SLEEP_AFTER_ACTION) -> None:
         """
         Double Click on the last found element.
 
@@ -925,11 +925,11 @@ class DesktopBot(BaseBot):
     @only_if_element
     def double_click_relative(
         self,
-        x,
-        y,
-        interval_between_clicks=0,
-        wait_after=config.DEFAULT_SLEEP_AFTER_ACTION,
-    ):
+        x: int,
+        y: int,
+        interval_between_clicks: int = 0,
+        wait_after: int = config.DEFAULT_SLEEP_AFTER_ACTION,
+    ) -> None:
         """
         Double Click Relative on the last found element.
 
@@ -949,7 +949,7 @@ class DesktopBot(BaseBot):
         )
 
     @only_if_element
-    def triple_click(self, wait_after=config.DEFAULT_SLEEP_AFTER_ACTION):
+    def triple_click(self, wait_after: int = config.DEFAULT_SLEEP_AFTER_ACTION) -> None:
         """
         Triple Click on the last found element.
 
@@ -961,11 +961,11 @@ class DesktopBot(BaseBot):
     @only_if_element
     def triple_click_relative(
         self,
-        x,
-        y,
-        interval_between_clicks=0,
-        wait_after=config.DEFAULT_SLEEP_AFTER_ACTION,
-    ):
+        x: int,
+        y: int,
+        interval_between_clicks: int = 0,
+        wait_after: int = config.DEFAULT_SLEEP_AFTER_ACTION,
+    ) -> None:
         """
         Triple Click Relative on the last found element.
 
@@ -985,8 +985,11 @@ class DesktopBot(BaseBot):
         )
 
     def mouse_down(
-        self, wait_after=config.DEFAULT_SLEEP_AFTER_ACTION, *, button="left"
-    ):
+        self,
+        wait_after: int = config.DEFAULT_SLEEP_AFTER_ACTION,
+        *,
+        button: Literal["left", "right", "middle"] = "left",
+    ) -> None:
         """
         Holds down the requested mouse button.
 
@@ -998,7 +1001,12 @@ class DesktopBot(BaseBot):
         self._mouse_controller.press(mouse_button)
         self.sleep(wait_after)
 
-    def mouse_up(self, wait_after=config.DEFAULT_SLEEP_AFTER_ACTION, *, button="left"):
+    def mouse_up(
+        self,
+        wait_after: int = config.DEFAULT_SLEEP_AFTER_ACTION,
+        *,
+        button: Literal["left", "right", "middle"] = "left",
+    ) -> None:
         """
         Releases the requested mouse button.
 
@@ -1010,7 +1018,7 @@ class DesktopBot(BaseBot):
         self._mouse_controller.release(mouse_button)
         self.sleep(wait_after)
 
-    def scroll_down(self, clicks):
+    def scroll_down(self, clicks: int) -> None:
         """
         Scroll Down n clicks
 
@@ -1020,7 +1028,7 @@ class DesktopBot(BaseBot):
         self._mouse_controller.scroll(0, -1 * clicks)
         self.sleep(config.DEFAULT_SLEEP_AFTER_ACTION)
 
-    def scroll_up(self, clicks):
+    def scroll_up(self, clicks: int) -> None:
         """
         Scroll Up n clicks
 
@@ -1031,7 +1039,7 @@ class DesktopBot(BaseBot):
         self.sleep(config.DEFAULT_SLEEP_AFTER_ACTION)
 
     @only_if_element
-    def move(self):
+    def move(self) -> None:
         """
         Move to the center position of last found item.
         """
@@ -1039,7 +1047,7 @@ class DesktopBot(BaseBot):
         self._mouse_controller.position = (x, y)
         self.sleep(config.DEFAULT_SLEEP_AFTER_ACTION)
 
-    def move_relative(self, x, y):
+    def move_relative(self, x: int, y: int) -> None:
         """
         Move the mouse relative to its current position.
 
@@ -1053,7 +1061,7 @@ class DesktopBot(BaseBot):
         self._mouse_controller.position = (x, y)
         self.sleep(config.DEFAULT_SLEEP_AFTER_ACTION)
 
-    def move_random(self, range_x, range_y):
+    def move_random(self, range_x: int, range_y: int) -> None:
         """
         Move randomly along the given x, y range.
 
@@ -1070,11 +1078,11 @@ class DesktopBot(BaseBot):
     @only_if_element
     def right_click(
         self,
-        wait_after=config.DEFAULT_SLEEP_AFTER_ACTION,
+        wait_after: int = config.DEFAULT_SLEEP_AFTER_ACTION,
         *,
-        clicks=1,
-        interval_between_clicks=0,
-    ):
+        clicks: int = 1,
+        interval_between_clicks: int = 0,
+    ) -> None:
         """
         Right click on the last found element.
 
@@ -1094,7 +1102,7 @@ class DesktopBot(BaseBot):
         )
         self.sleep(wait_after)
 
-    def right_click_at(self, x, y):
+    def right_click_at(self, x: int, y: int) -> None:
         """
         Right click at the coordinate defined by x and y
 
@@ -1107,11 +1115,11 @@ class DesktopBot(BaseBot):
     @only_if_element
     def right_click_relative(
         self,
-        x,
-        y,
-        interval_between_clicks=0,
-        wait_after=config.DEFAULT_SLEEP_AFTER_ACTION,
-    ):
+        x: int,
+        y: int,
+        interval_between_clicks: int = 0,
+        wait_after: int = config.DEFAULT_SLEEP_AFTER_ACTION,
+    ) -> None:
         """
         Right Click Relative on the last found element.
 

--- a/botcity/core/bot.py
+++ b/botcity/core/bot.py
@@ -20,7 +20,7 @@ from pynput.keyboard import Key, KeyCode
 from pynput.mouse import Controller as MouseController
 
 from . import config, cv2find
-from .input_utils import _mouse_click, keys_map
+from .input_utils import _mouse_click, keys_map, mouse_map
 
 try:
     from pywinauto.application import Application, WindowSpecification
@@ -999,8 +999,8 @@ class DesktopBot(BaseBot):
             wait_after (int, optional): Interval to wait after clicking on the element.
             button (str, optional): One of 'left', 'right', 'middle'. Defaults to 'left'
         """
-
-        self._mouse_controller.press(button)
+        mouse_button = mouse_map.get(button, None)
+        self._mouse_controller.press(mouse_button)
         self.sleep(wait_after)
 
     def mouse_up(
@@ -1016,8 +1016,8 @@ class DesktopBot(BaseBot):
             wait_after (int, optional): Interval to wait after clicking on the element.
             button (str, optional): One of 'left', 'right', 'middle'. Defaults to 'left'
         """
-
-        self._mouse_controller.release(button)
+        mouse_button = mouse_map.get(button, None)
+        self._mouse_controller.release(mouse_button)
         self.sleep(wait_after)
 
     def scroll_down(self, clicks: int) -> None:

--- a/botcity/core/bot.py
+++ b/botcity/core/bot.py
@@ -879,10 +879,8 @@ class DesktopBot(BaseBot):
         """
         x, y = self.state.center()
 
-        mouse_button = mouse_map.get(button, "left")
-
         _mouse_click(
-            self._mouse_controller, x, y, clicks, interval_between_clicks, mouse_button
+            self._mouse_controller, x, y, clicks, interval_between_clicks, button
         )
         self.sleep(wait_after)
 
@@ -911,10 +909,8 @@ class DesktopBot(BaseBot):
         x = self.state.x() + x
         y = self.state.y() + y
 
-        mouse_button = mouse_map.get(button, "left")
-
         _mouse_click(
-            self._mouse_controller, x, y, clicks, interval_between_clicks, mouse_button
+            self._mouse_controller, x, y, clicks, interval_between_clicks, button
         )
         self.sleep(wait_after)
 
@@ -1003,9 +999,8 @@ class DesktopBot(BaseBot):
             wait_after (int, optional): Interval to wait after clicking on the element.
             button (str, optional): One of 'left', 'right', 'middle'. Defaults to 'left'
         """
-        mouse_button = mouse_map.get(button, "left")
 
-        self._mouse_controller.press(mouse_button)
+        self._mouse_controller.press(button)
         self.sleep(wait_after)
 
     def mouse_up(
@@ -1021,9 +1016,8 @@ class DesktopBot(BaseBot):
             wait_after (int, optional): Interval to wait after clicking on the element.
             button (str, optional): One of 'left', 'right', 'middle'. Defaults to 'left'
         """
-        mouse_button = mouse_map.get(button, "left")
 
-        self._mouse_controller.release(mouse_button)
+        self._mouse_controller.release(button)
         self.sleep(wait_after)
 
     def scroll_down(self, clicks: int) -> None:

--- a/botcity/core/bot.py
+++ b/botcity/core/bot.py
@@ -20,7 +20,7 @@ from pynput.keyboard import Key, KeyCode
 from pynput.mouse import Controller as MouseController
 
 from . import config, cv2find
-from .input_utils import _mouse_click, keys_map, mouse_map
+from .input_utils import _mouse_click, keys_map
 
 try:
     from pywinauto.application import Application, WindowSpecification

--- a/botcity/core/bot.py
+++ b/botcity/core/bot.py
@@ -6,7 +6,7 @@ import random
 import subprocess
 import time
 import webbrowser
-from typing import Union, Tuple, Optional, List, Dict, Generator, Any, Literal
+from typing import Union, Tuple, Optional, List, Dict, Generator, Any
 
 from numpy import ndarray
 
@@ -866,7 +866,7 @@ class DesktopBot(BaseBot):
         *,
         clicks: int = 1,
         interval_between_clicks: int = 0,
-        button: Literal["left", "right", "middle"] = "left",
+        button: str = "left",
     ) -> None:
         """
         Click on the last found element.
@@ -878,8 +878,11 @@ class DesktopBot(BaseBot):
             button (str, optional): One of 'left', 'right', 'middle'. Defaults to 'left'
         """
         x, y = self.state.center()
+
+        mouse_button = mouse_map.get(button, "left")
+
         _mouse_click(
-            self._mouse_controller, x, y, clicks, interval_between_clicks, button
+            self._mouse_controller, x, y, clicks, interval_between_clicks, mouse_button
         )
         self.sleep(wait_after)
 
@@ -892,7 +895,7 @@ class DesktopBot(BaseBot):
         *,
         clicks: int = 1,
         interval_between_clicks: int = 0,
-        button: Literal["left", "right", "middle"] = "left",
+        button: str = "left",
     ) -> None:
         """
         Click Relative on the last found element.
@@ -907,8 +910,11 @@ class DesktopBot(BaseBot):
         """
         x = self.state.x() + x
         y = self.state.y() + y
+
+        mouse_button = mouse_map.get(button, "left")
+
         _mouse_click(
-            self._mouse_controller, x, y, clicks, interval_between_clicks, button
+            self._mouse_controller, x, y, clicks, interval_between_clicks, mouse_button
         )
         self.sleep(wait_after)
 
@@ -988,7 +994,7 @@ class DesktopBot(BaseBot):
         self,
         wait_after: int = config.DEFAULT_SLEEP_AFTER_ACTION,
         *,
-        button: Literal["left", "right", "middle"] = "left",
+        button: str = "left",
     ) -> None:
         """
         Holds down the requested mouse button.
@@ -997,7 +1003,8 @@ class DesktopBot(BaseBot):
             wait_after (int, optional): Interval to wait after clicking on the element.
             button (str, optional): One of 'left', 'right', 'middle'. Defaults to 'left'
         """
-        mouse_button = mouse_map.get(button, None)
+        mouse_button = mouse_map.get(button, "left")
+
         self._mouse_controller.press(mouse_button)
         self.sleep(wait_after)
 
@@ -1005,7 +1012,7 @@ class DesktopBot(BaseBot):
         self,
         wait_after: int = config.DEFAULT_SLEEP_AFTER_ACTION,
         *,
-        button: Literal["left", "right", "middle"] = "left",
+        button: str = "left",
     ) -> None:
         """
         Releases the requested mouse button.
@@ -1014,7 +1021,8 @@ class DesktopBot(BaseBot):
             wait_after (int, optional): Interval to wait after clicking on the element.
             button (str, optional): One of 'left', 'right', 'middle'. Defaults to 'left'
         """
-        mouse_button = mouse_map.get(button, None)
+        mouse_button = mouse_map.get(button, "left")
+
         self._mouse_controller.release(mouse_button)
         self.sleep(wait_after)
 

--- a/botcity/core/input_utils.py
+++ b/botcity/core/input_utils.py
@@ -5,22 +5,22 @@ from pynput.keyboard import Key
 from pynput.mouse import Button, Controller
 
 keys_map = {
-    "num0": '0',
-    "num1": '1',
-    "num2": '2',
-    "num3": '3',
-    "num4": '4',
-    "num5": '5',
-    "num6": '6',
-    "num7": '7',
-    "num8": '8',
-    "num9": '9',
-    "add": '+',
-    "decimal": ',',
-    "subtract": '-',
-    "multiply": '*',
-    "divide": '/',
-    "separator": '|',
+    "num0": "0",
+    "num1": "1",
+    "num2": "2",
+    "num3": "3",
+    "num4": "4",
+    "num5": "5",
+    "num6": "6",
+    "num7": "7",
+    "num8": "8",
+    "num9": "9",
+    "add": "+",
+    "decimal": ",",
+    "subtract": "-",
+    "multiply": "*",
+    "divide": "/",
+    "separator": "|",
     "altleft": Key.alt_l,
     "altright": Key.alt_r,
     "capslock": Key.caps_lock,
@@ -43,14 +43,14 @@ keys_map = {
     "volumeup": Key.media_volume_up,
     "prevtrack": Key.media_previous,
     "nexttrack": Key.media_next,
-    "return": Key.enter
+    "return": Key.enter,
 }
 
 if platform.system() != "Darwin":
     keys_map.update(
         {
             "numlock": Key.num_lock,
-            "prtsc":  Key.print_screen,
+            "prtsc": Key.print_screen,
             "prtscr": Key.print_screen,
             "printscreen": Key.print_screen,
             "prntscrn": Key.print_screen,
@@ -59,25 +59,33 @@ if platform.system() != "Darwin":
         }
     )
 
-mouse_map = {
-    "left": Button.left,
-    "right": Button.right,
-    "middle": Button.middle
-}
+mouse_map = {"left": Button.left, "right": Button.right, "middle": Button.middle}
 
 
-def _mouse_click(mouse_controller: Controller, x: int, y: int, clicks=1, interval_between_clicks=0, button='left'):
+def _mouse_click(
+    mouse_controller: Controller,
+    x: int,
+    y: int,
+    clicks: int = 1,
+    interval_between_clicks: int = 0,
+    button: str = "left",
+) -> None:
     """
     Moves the mouse and clicks at the coordinate defined by x and y.
     """
     if platform.system() == "Darwin":
         from . import os_compat
-        os_compat.osx_click(x=x, y=y, clicks=clicks, interval=interval_between_clicks, button=button)
+
+        os_compat.osx_click(
+            x=x, y=y, clicks=clicks, interval=interval_between_clicks, button=button
+        )
     else:
         mouse_button = mouse_map.get(button, None)
         if not mouse_button:
-            raise ValueError(f'''Invalid mouse button name.
-            The mouse button has to be one of these values: {list(mouse_map.keys())}''')
+            raise ValueError(
+                f"""Invalid mouse button name.
+            The mouse button has to be one of these values: {list(mouse_map.keys())}"""
+            )
 
         mouse_controller.position = (x, y)
         time.sleep(0.1)


### PR DESCRIPTION
- Added explicit return types to various DesktopBot methods.
- Introduced Literal for button parameters to restrict values:
   - I realized that the Button type is an Enum, from now on the bot only accepts the literal values of left, right and middle because I didn't find a better way to represent this enum, what do you guys think.
- Ensured consistent type annotations across mouse-related functions.